### PR TITLE
removed old repo prefix

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -2,7 +2,7 @@ const site = require("./config/site");
 const plugins = require("./config/plugins");
 
 module.exports = {
-  pathPrefix: `/red-thread`,
+  pathPrefix: ``,
   siteMetadata: site,
   plugins,
 };


### PR DESCRIPTION
## :scroll: Description

I changed the repository name.

## 💡 Motivation and Context

Closes #31 

## 🔮 Next steps

If we ever need to add a prefix again, the option is there. Just edit `gatsby-config.js`

## :camera: Screenshots / GIFs / Videos

n/a
