### PR TITLE
Link colors

### DIFF
--- a/src/layout/Layout.jsx
+++ b/src/layout/Layout.jsx
@@ -16,6 +16,9 @@ const useStyles = makeStyles((theme) => ({
   },
   main: {
     marginTop: theme.spacing(1.125),
+    "& a": {
+      color: theme.palette.text.secondary,
+    },
   },
 }));
 


### PR DESCRIPTION
## :scroll: Description

Makes all <a> tags within an article abide by textSecondary from the color palette.

## 💡 Motivation and Context

Links are not legible with the dark theme

## 🔮 Next steps

N/A

## :camera: Screenshots / GIFs / Videos
Light theme:
![Screen Capture_select-area_20201030190005](https://user-images.githubusercontent.com/19642235/97763521-3dff3a80-1ae2-11eb-8b4a-d158843e3c90.png)

Dark theme:
![Screen Capture_select-area_20201030190020](https://user-images.githubusercontent.com/19642235/97763534-448db200-1ae2-11eb-8b8e-d4d726771ae0.png)

