### PR TITLE
Fix link colors

### DIFF
--- a/src/layout/Layout.jsx
+++ b/src/layout/Layout.jsx
@@ -16,9 +16,6 @@ const useStyles = makeStyles((theme) => ({
   },
   main: {
     marginTop: theme.spacing(1.125),
-    "& a": {
-      color: theme.palette.text.secondary,
-    },
   },
 }));
 

--- a/src/templates/article.jsx
+++ b/src/templates/article.jsx
@@ -27,6 +27,11 @@ const useStyles = makeStyles((theme) => ({
   chips: {
     marginRight: theme.spacing(1),
   },
+  main: {
+    "& a": {
+      color: theme.palette.text.secondary,
+    }
+  },
 }));
 
 const Article = ({ data, pageContext }) => {
@@ -73,7 +78,9 @@ const Article = ({ data, pageContext }) => {
       <Typography variant="subtitle1">
         <time>{frontmatter.date}</time>&nbsp;&middot;&nbsp;{timeToRead + " min read"}
       </Typography>
-      <MDXRenderer>{body}</MDXRenderer>
+      <div className={classes.main}>
+        <MDXRenderer>{body}</MDXRenderer>
+      </div>
       {/*Article Tags*/}
       <p>
         Tagged: {frontmatter.tags.map(tag => 


### PR DESCRIPTION
## :scroll: Description

Fix link color implementation from #56

## 💡 Motivation and Context

That implementation applied the style to all <a> tags, not just in the article

## 🔮 Next steps

## :camera: Screenshots / GIFs / Videos