### PR TITLE
Feat/typography

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "@mdx-js/react": "^1.6.16",
     "clsx": "^1.1.1",
     "deepmerge": "^4.2.2",
+    "fontsource-exo-2": "^3.0.5",
+    "fontsource-montserrat": "^3.0.9",
     "fontsource-roboto": "^3.0.3",
     "fontsource-roboto-slab": "^3.0.3",
     "gatsby": "^2.24.23",

--- a/src/assets/styles/article.css
+++ b/src/assets/styles/article.css
@@ -16,7 +16,7 @@
 	#article-body blockquote,
 	#article-body pre
 	{
-		width: 600px;
+		width: 680px;
 		margin-left: auto;
 		margin-right: auto;
 	}

--- a/src/assets/styles/article.css
+++ b/src/assets/styles/article.css
@@ -1,0 +1,41 @@
+#article-body {
+	font-family: "Roboto";
+	font-size: 18px;
+}
+
+@media screen and (min-width: 700px) {
+	#article-body p,
+	#article-body h1,
+	#article-body h2,
+	#article-body h3,
+	#article-body h4,
+	#article-body h5,
+	#article-body h6,
+	#article-body ul,
+	#article-body ol,
+	#article-body blockquote,
+	#article-body pre
+	{
+		width: 600px;
+		margin-left: auto;
+		margin-right: auto;
+	}
+
+	#article-body pre {
+		text-align: left;
+		overflow-x: scroll;
+	}
+}
+
+#article-body code {
+	font-size: 1rem;
+}
+
+#article-body pre {
+	padding: 0.5rem 0.5rem;
+}
+
+#article-body blockquote {
+	padding-left: 20px;
+	border-left: 3px solid rgba(128,128,128,0.5);
+}

--- a/src/assets/styles/article.css
+++ b/src/assets/styles/article.css
@@ -1,5 +1,5 @@
 #article-body {
-	font-family: "Roboto";
+	font-family: "Exo 2", sans-serif;
 	font-size: 18px;
 }
 
@@ -38,4 +38,15 @@
 #article-body blockquote {
 	padding-left: 20px;
 	border-left: 3px solid rgba(128,128,128,0.5);
+	font-style: italic;
+}
+
+#article-body h1,
+#article-body h2,
+#article-body h3,
+#article-body h4,
+#article-body h5,
+#article-body h6
+{
+	font-family: "Montserrat", sans-serif;
 }

--- a/src/pages/about.jsx
+++ b/src/pages/about.jsx
@@ -19,7 +19,7 @@ const AboutPanel = (props) => {
   const classes = useStyles();
   return (
     <div className={classes.aboutPanel}>
-      <Typography variant="h5">{props.title}</Typography>
+      <Typography variant="h4">{props.title}</Typography>
       <Typography variant="body1">{props.children}</Typography>
     </div>
   );
@@ -30,7 +30,7 @@ const AboutPage = () => {
   return (
     <Layout>
       <SEO title="About" />
-      <Typography variant="h4" align="center">
+      <Typography variant="h3" align="center">
         About <i>The Icarus</i>
       </Typography>
       <AboutPanel title="What Is It?">

--- a/src/templates/article.jsx
+++ b/src/templates/article.jsx
@@ -22,7 +22,6 @@ const useStyles = makeStyles((theme) => ({
     },
   },
   link: {
-    color: theme.palette.text.secondary,
     verticalAlign: "center",
   },
   chips: {
@@ -68,6 +67,7 @@ const Article = ({ data, pageContext }) => {
                   component={GatsbyLink}
                   to={`/author/${a.username}`}
                   className={classes.link}
+                  color="textSecondary"
                 >
                   {a.display_name}
                 </Link>
@@ -83,6 +83,7 @@ const Article = ({ data, pageContext }) => {
         <time>{frontmatter.date}</time>&nbsp;&middot;&nbsp;
         {timeToRead + " min read"}
       </Typography>
+      {/*Article Body*/}
       <div className={classes.main} id="article-body">
         <MDXRenderer>{body}</MDXRenderer>
       </div>
@@ -103,6 +104,7 @@ const Article = ({ data, pageContext }) => {
                 to={`/articles/${pageContext.prev.node.fields.slug}`}
                 component={GatsbyLink}
                 className={classes.link}
+                color="textSecondary"
               >
                 {pageContext.prev.node.frontmatter.title}
               </Link>
@@ -116,6 +118,7 @@ const Article = ({ data, pageContext }) => {
                 to={`/articles/${pageContext.next.node.fields.slug}`}
                 component={GatsbyLink}
                 className={classes.link}
+                color="textSecondary"
               >
                 {pageContext.next.node.frontmatter.title}
               </Link>

--- a/src/templates/article.jsx
+++ b/src/templates/article.jsx
@@ -12,6 +12,7 @@ import { makeStyles } from "@material-ui/core/styles";
 import SEO from "src/components/SEO";
 import TagChip from "src/components/tagchip";
 import Layout from "src/layout";
+import "../assets/styles/article.css";
 
 const useStyles = makeStyles((theme) => ({
   avatarContainer: {
@@ -82,7 +83,7 @@ const Article = ({ data, pageContext }) => {
         <time>{frontmatter.date}</time>&nbsp;&middot;&nbsp;
         {timeToRead + " min read"}
       </Typography>
-      <div className={classes.main}>
+      <div className={classes.main} id="article-body">
         <MDXRenderer>{body}</MDXRenderer>
       </div>
       {/*Article Tags*/}

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,6 +1,6 @@
 import deepMerge from "deepmerge";
 import { createMuiTheme, responsiveFontSizes } from "@material-ui/core/styles";
-import "fontsource-montserrat/600.css"
+import "fontsource-montserrat/700.css"
 import "fontsource-exo-2/400.css";
 
 /*
@@ -15,7 +15,7 @@ import "fontsource-exo-2/400.css";
 const makeTheme = (variant) => {
   const heading = {
     fontFamily: 'Montserrat, sans-serif',
-    fontWeight: 600,
+    fontWeight: 700,
   };
   const common = {
     typography: {

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,5 +1,7 @@
 import deepMerge from "deepmerge";
 import { createMuiTheme, responsiveFontSizes } from "@material-ui/core/styles";
+import "fontsource-montserrat/600.css"
+import "fontsource-exo-2/400.css";
 
 /*
  * Current theme:
@@ -11,7 +13,19 @@ import { createMuiTheme, responsiveFontSizes } from "@material-ui/core/styles";
  */
 
 const makeTheme = (variant) => {
-  const common = {};
+  const heading = {
+    fontFamily: 'Montserrat, sans-serif',
+    fontWeight: 600,
+  };
+  const common = {
+    typography: {
+      fontFamily: '"Exo 2", Roboto, sans-serif',
+      fontWeight: 400,
+      fontSize: 16,
+      h3: heading,
+      h4: heading,
+    }
+  };
 
   const theme = createMuiTheme(deepMerge(common, variant));
   return responsiveFontSizes(theme);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5039,6 +5039,16 @@ follow-redirects@^1.0.0:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.12.1.tgz#de54a6205311b93d60398ebc01cf7015682312b6"
   integrity sha512-tmRv0AVuR7ZyouUHLeNSiO6pqulF7dYa3s19c6t+wz9LD69/uSzdMxJ2S91nTI9U3rt/IldxpzMOFejp6f0hjg==
 
+fontsource-exo-2@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/fontsource-exo-2/-/fontsource-exo-2-3.0.5.tgz#4356777c68ea54b29a3d9a38e3d23354fa4e46df"
+  integrity sha512-vRuQJL/GP7+zSzFieTEJgj1LwGRTfFi7NoOjBxEsvSjcpaqzhJBwv6wZbNkudlOfSq4MfzWU5POXmSy+lkGdDA==
+
+fontsource-montserrat@^3.0.9:
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/fontsource-montserrat/-/fontsource-montserrat-3.0.9.tgz#ff614725c420839c4aefbca6f2b49c6224050991"
+  integrity sha512-kSE4GwWoEKJlIp0UyuoYtBvjKv5kwOTK7EvCwdQ7ukvKvgIK1LR5+GpZC5c/juonasNtFTKav67Zd7/C7m+a5w==
+
 fontsource-roboto-slab@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/fontsource-roboto-slab/-/fontsource-roboto-slab-3.0.3.tgz#84907e38d3e43e3b532cf1c5a6d55a1228be077f"


### PR DESCRIPTION
## :scroll: Description

Addresses #53 . 

1. Introduces more consistent and interesting typography to the website. 
    1. Montserrat for headings
    2. Exo 2 for body
    3. bigger body font size
2. Article body is constrained to a single column like on all journalistic/blog websites.

## 💡 Motivation and Context

Drew inspiration from [primaryobjects.com](http://www.primaryobjects.com/2020/01/26/intelligent-heuristics-for-the-game-isolation-using-ai-and-minimax/).

## 🔮 Next steps

Figure out why links colors don't update. I tried replacing the mdx-generated links with Material-UI ones to no avail. Shan said the `useTheme()` hook doesn't do anything either.

Imo, this is growing hard to maintain. Material-ui is providing little value, and the gatsby file structure is confusing. The next generation will never be able to figure out which CSS file is used where, how to use CSS-in-JS, how to add new pages, etc. We have a total of 10 comments.

## :camera: Screenshots / GIFs / Videos

Home page in dark mode
![image](https://user-images.githubusercontent.com/6315096/99780379-6c21da00-2ae4-11eb-8619-59b4a22d84c5.png)

Home page in light mode
![image](https://user-images.githubusercontent.com/6315096/99780428-7a6ff600-2ae4-11eb-9e43-b12e3b0bf759.png)

Article in dark mode
![image](https://user-images.githubusercontent.com/6315096/99780541-a2f7f000-2ae4-11eb-9cb4-f3c7373c466a.png)

Article in light mode
![image](https://user-images.githubusercontent.com/6315096/99780573-ac815800-2ae4-11eb-9a49-458e3b9da1df.png)
