### PR TITLE
Feat/comments

### DIFF
--- a/config/plugins.js
+++ b/config/plugins.js
@@ -110,4 +110,10 @@ module.exports = [
       exclude: ["/404.html", "/tag/*"],
     },
   },
+  {
+    resolve: "gatsby-plugin-disqus",
+    options: {
+      shortname: "the-icarus"
+    }
+  },
 ];

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "fontsource-roboto": "^3.0.3",
     "fontsource-roboto-slab": "^3.0.3",
     "gatsby": "^2.24.23",
+    "gatsby-plugin-disqus": "^1.2.2",
     "gatsby-plugin-feed": "^2.5.11",
     "gatsby-plugin-material-ui": "^2.1.10",
     "gatsby-plugin-mdx": "^1.2.33",

--- a/src/templates/article.jsx
+++ b/src/templates/article.jsx
@@ -8,7 +8,7 @@ import Grid from "@material-ui/core/Grid";
 import ArrowBackIcon from "@material-ui/icons/ArrowBack";
 import ArrowForwardIcon from "@material-ui/icons/ArrowForward";
 import { makeStyles } from "@material-ui/core/styles";
-import { Disqus, CommentCount } from 'gatsby-plugin-disqus';
+import { Disqus } from 'gatsby-plugin-disqus';
 
 import SEO from "src/components/SEO";
 import TagChip from "src/components/tagchip";
@@ -90,18 +90,17 @@ const Article = ({ data, pageContext, location }) => {
         <time>{frontmatter.date}</time>&nbsp;&middot;&nbsp;
         {timeToRead + " min read"}
       </Typography>
-      <CommentCount config={disqusConfig} placeholder="{num} comments" />
       {/*Article Body*/}
       <div className={classes.main} id="article-body">
         <MDXRenderer>{body}</MDXRenderer>
+        {/*Article Tags*/}
+        <p>
+          Tagged:{" "}
+          {frontmatter.tags.map((tag) => (
+            <TagChip className={classes.chips} name={tag} label={tag} />
+          ))}
+        </p>
       </div>
-      {/*Article Tags*/}
-      <p>
-        Tagged:{" "}
-        {frontmatter.tags.map((tag) => (
-          <TagChip className={classes.chips} name={tag} label={tag} />
-        ))}
-      </p>
       {/* Comments Section */}
       <Disqus config={disqusConfig} />
       {/* Links to other articles */}

--- a/src/templates/article.jsx
+++ b/src/templates/article.jsx
@@ -8,6 +8,7 @@ import Grid from "@material-ui/core/Grid";
 import ArrowBackIcon from "@material-ui/icons/ArrowBack";
 import ArrowForwardIcon from "@material-ui/icons/ArrowForward";
 import { makeStyles } from "@material-ui/core/styles";
+import { Disqus, CommentCount } from 'gatsby-plugin-disqus';
 
 import SEO from "src/components/SEO";
 import TagChip from "src/components/tagchip";
@@ -34,12 +35,18 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const Article = ({ data, pageContext }) => {
+const Article = ({ data, pageContext, location }) => {
   const { frontmatter, excerpt, body, timeToRead } = data.mdx;
   const classes = useStyles();
   const related = [];
   if (pageContext.prev) related.push(pageContext.prev);
   if (pageContext.next) related.push(pageContext.next);
+  //needed to initialize Disqus comments, unique for each page
+  const disqusConfig = {
+    url: `${data.site.siteMetadata.siteUrl}${location.pathname}`,
+    identifier: pageContext.slug,
+    title: frontmatter.title
+  };
   return (
     <Layout>
       <SEO title={frontmatter.title} description={excerpt} article={true} />
@@ -83,6 +90,7 @@ const Article = ({ data, pageContext }) => {
         <time>{frontmatter.date}</time>&nbsp;&middot;&nbsp;
         {timeToRead + " min read"}
       </Typography>
+      <CommentCount config={disqusConfig} placeholder="{num} comments" />
       {/*Article Body*/}
       <div className={classes.main} id="article-body">
         <MDXRenderer>{body}</MDXRenderer>
@@ -94,6 +102,8 @@ const Article = ({ data, pageContext }) => {
           <TagChip className={classes.chips} name={tag} label={tag} />
         ))}
       </p>
+      {/* Comments Section */}
+      <Disqus config={disqusConfig} />
       {/* Links to other articles */}
       <Grid container justify="space-between">
         <Grid item>
@@ -147,6 +157,11 @@ export const query = graphql`
       }
       timeToRead
       body
+    }
+    site {
+      siteMetadata {
+        siteUrl
+      }
     }
   }
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5244,6 +5244,11 @@ gatsby-page-utils@^0.2.19:
     lodash "^4.17.15"
     micromatch "^3.1.10"
 
+gatsby-plugin-disqus@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-disqus/-/gatsby-plugin-disqus-1.2.2.tgz#d10e72c2ac0f7205abd7dda2e8cb4ecc0743a824"
+  integrity sha512-RWiU8Jtg94kVphjBnxqnF+0txyJ3eZN/9vw/VlMgz0mor1FwULkiiiOyNXAJxbX6tFqYmypnmfa+edQWX/rMpQ==
+
 gatsby-plugin-feed@^2.5.11:
   version "2.5.11"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-feed/-/gatsby-plugin-feed-2.5.11.tgz#64b6ec5a291df23bece4471a82186437b5a20fc6"


### PR DESCRIPTION
## :scroll: Description

I added a basic Disqus comments section to the bottom of every article. It is below the tags and above the footer/related links.

## 💡 Motivation and Context

Closes #52 .

## 🔮 Next steps

Figure out if the `CommentCount` component is broken. Right now it is, but like is it deprecated?

## :camera: Screenshots / GIFs / Videos

Light mode:
![image](https://user-images.githubusercontent.com/6315096/99788457-21598f80-2aef-11eb-8eab-fe6b46291be8.png)

Dark mode:
![image](https://user-images.githubusercontent.com/6315096/99788525-38987d00-2aef-11eb-96fb-315154078a97.png)

